### PR TITLE
Create petition endpoint will return job status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :sinatra do
   gem 'sinatra-contrib'
   gem 'httparty'
   gem 'sidekiq'
+  gem 'sidekiq-status'
 end
 
 group :spec do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    sidekiq-status (0.5.4)
+      sidekiq (>= 2.7)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -104,6 +106,7 @@ DEPENDENCIES
   httparty
   rspec (~> 3.2)
   sidekiq
+  sidekiq-status
   sinatra (~> 1.4, >= 1.4.6)
   sinatra-contrib
 

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require 'sinatra'
+require 'sinatra/json'
 require File.expand_path '../workers/ping_worker.rb', __FILE__
 
 get '/' do
@@ -6,5 +7,8 @@ get '/' do
 end
 
 post '/petitions' do
-  PingWorker.perform_async params[:message]
+  json({
+    job: PingWorker.perform_async(params[:message]),
+    status: "pending"
+  })
 end

--- a/app.rb
+++ b/app.rb
@@ -1,14 +1,33 @@
 require 'sinatra'
 require 'sinatra/json'
+require 'sidekiq'
+require 'sidekiq-status'
+
 require File.expand_path '../workers/ping_worker.rb', __FILE__
+
+configure do
+  Sidekiq.configure_client do |config|
+    config.client_middleware do |chain|
+      chain.add Sidekiq::Status::ClientMiddleware
+    end
+  end
+
+  Sidekiq.configure_server do |config|
+    config.server_middleware do |chain|
+      chain.add Sidekiq::Status::ServerMiddleware, expiration: 30.minutes # default
+    end
+    config.client_middleware do |chain|
+      chain.add Sidekiq::Status::ClientMiddleware
+    end
+  end
+end
 
 get '/' do
   "hello world"
 end
 
 post '/petitions' do
-  json({
-    job: PingWorker.perform_async(params[:message]),
-    status: "pending"
-  })
+  job_id = PingWorker.perform_async(params[:message])
+  job_status = Sidekiq::Status::status(job_id)
+  json job: job_id, status: job_status
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -9,7 +9,8 @@ describe "My info-bazooka" do
   it "should return job id for petition worker" do
     post '/petitions', message: "ping"
     job_id = PingWorker.jobs.last['jid']
-    response = { :job => job_id, :status => "pending" }
+    job_status = Sidekiq::Status::status(job_id)
+    response = { :job => job_id, :status => job_status }
     expect(last_response.body).to eq(response.to_json)
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -5,4 +5,11 @@ describe "My info-bazooka" do
     get '/'
     expect(last_response.body).to eq("hello world")
   end
+
+  it "should return job id for petition worker" do
+    post '/petitions', message: "ping"
+    job_id = PingWorker.jobs.last['jid']
+    response = { :job => job_id, :status => "pending" }
+    expect(last_response.body).to eq(response.to_json)
+  end
 end

--- a/workers/ping_worker.rb
+++ b/workers/ping_worker.rb
@@ -1,5 +1,3 @@
-require 'sidekiq'
-
 class PingWorker
   include Sidekiq::Worker
   def perform(message)


### PR DESCRIPTION
Depends on #7 

```bash
➜  info-bazooka git:(create-petition) curl -i -d "message=FUBAR" localhost:5000/petitions
HTTP/1.1 200 OK 
Content-Type: application/json
Content-Length: 53
X-Content-Type-Options: nosniff
Server: WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
Date: Sun, 08 Nov 2015 04:40:14 GMT
Connection: Keep-Alive

{"job":"32117ecd590160a2b8544ff3","status":"pending"}
```